### PR TITLE
Ability to overwrite output files using overwrite attribute.

### DIFF
--- a/Source/TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter/Configuration.cs
+++ b/Source/TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter/Configuration.cs
@@ -30,6 +30,9 @@ namespace TheBoxSoftware.Exporter
             [XmlAttribute("location")]
             public string Location { get; set; }
 
+            [XmlAttribute("overwrite")]
+            public bool Overwrite { get; set; } = false;
+
             [XmlText()]
             public string File { get; set; }
         }

--- a/Source/TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter/Exporter.cs
+++ b/Source/TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter/Exporter.cs
@@ -128,6 +128,7 @@ namespace TheBoxSoftware.Exporter
             else
             {
                 settings.PublishDirectory = output.Location;
+                settings.OverwritePublishDirectory = output.Overwrite;
 
                 export.Exporter exporter = export.Exporter.Create(document, settings, config);
                 exporter.ExportStep += new export.ExportStepEventHandler(exporter_ExportStep);

--- a/Source/TheBoxSoftware.Documentation/Exporting/ExportSettings.cs
+++ b/Source/TheBoxSoftware.Documentation/Exporting/ExportSettings.cs
@@ -44,5 +44,10 @@ namespace TheBoxSoftware.Documentation.Exporting
             get { return _publishDirectory; }
             set { _publishDirectory = value; }
         }
+
+        /// <summary>
+        /// Whether to overwrite the <see cref="PublishDirectory"/> or to create a new one.
+        /// </summary>
+        public bool OverwritePublishDirectory { get; set; }
     }
 }

--- a/Source/TheBoxSoftware.Documentation/Exporting/Exporter.cs
+++ b/Source/TheBoxSoftware.Documentation/Exporting/Exporter.cs
@@ -217,7 +217,12 @@ namespace TheBoxSoftware.Documentation.Exporting
             // #38 always add a new export directory to the publish location, this is to stop people deleting their
             // files and folders.
             DateTime now = DateTime.Now;
-            this.PublishDirectory = Path.Combine(PublishDirectory, string.Format("LD Export - {4:0000}{3:00}{2:00} {1:00}{0:00}\\", now.Minute, now.Hour, now.Day, now.Month, now.Year));
+            if (_settings.OverwritePublishDirectory) {
+                this.PublishDirectory = Path.Combine(PublishDirectory, "LD Export\\");
+            }
+            else {
+                this.PublishDirectory = Path.Combine(PublishDirectory, string.Format("LD Export - {4:0000}{3:00}{2:00} {1:00}{0:00}\\", now.Minute, now.Hour, now.Day, now.Month, now.Year));
+            }
 
             if (_fileSystem.DirectoryExists(PublishDirectory))
             {


### PR DESCRIPTION
If attribute set to true, output files will be in a folder called 'LD Export' instead of 'LD Export - <timestamp>'

Until further development can be made to change output directly name, and even output directly file, this change introduces an XML attribute of 'overwrite' to the configuration. It defaults to false, so to use it add it to the ldec element and set it to true: <ldec location="..." overwrite="true">...</ldec>