### PR TITLE
Feature/support tuple syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cs text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+Build the entire solution:
+```
+dotnet build developersuite.sln
+```
+
+Build a specific project:
+```
+dotnet build Source/TheBoxSoftware.Reflection/TheBoxSoftware.Reflection.csproj
+```
+
+Run all tests:
+```
+dotnet test developersuite.sln
+```
+
+Run tests for a specific project:
+```
+dotnet test Source/TheBoxSoftware.Reflection.Tests/TheBoxSoftware.Reflection.Tests.csproj
+```
+
+Run a single test by name:
+```
+dotnet test Source/TheBoxSoftware.Reflection.Tests/TheBoxSoftware.Reflection.Tests.csproj --filter "FullyQualifiedName~TestName"
+```
+
+Run the console exporter (after build):
+```
+Source/TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter/bin/Debug/netcoreapp3.1/win-x64/exporter.exe <filename> [modifiers]
+```
+
+Exporter usage:
+```
+exporter <filename> -to <output-dir> -format <ldec-file> -filters "public|protected"
+exporter config.xml   # use a configuration XML file
+```
+
+## Architecture
+
+Live Documenter is a .NET documentation suite with three modes: a WPF desktop application, a console exporter, and a library API. The solution (`developersuite.sln`) targets Windows, with core libraries on `netstandard2.0` and applications on `netcoreapp3.1`.
+
+### Project dependency chain
+
+```
+TheBoxSoftware (netstandard2.0)         — shared utilities and diagnostics
+    └── TheBoxSoftware.Reflection       — PE/COFF binary parser and reflection model
+            └── TheBoxSoftware.Documentation  — document model, mappers, exporters
+                    └── TheBoxSoftware.API.LiveDocumenter  — public API surface
+                    └── TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter  — console app
+                    └── TheBoxSoftware.DeveloperSuite.LiveDocumenter  — WPF desktop app (Windows-only)
+```
+
+### TheBoxSoftware.Reflection
+
+Reads .NET PE/COFF binaries directly without loading them into the runtime. Key types:
+
+- `PeCoffFile` — parses the PE file format, locates the CLR metadata directory
+- `AssemblyDef` — top-level reflection entry point, created via `AssemblyDef.Create(fileName)`
+- `TypeDef`, `MethodDef`, `FieldDef`, `PropertyDef`, `EventDef`, `ParamDef` — reflected member types
+- `Core/COFF/` — low-level metadata table row types (one file per ECMA-335 metadata table)
+- `Comments/` — parses the XML documentation comment files (`.xml`) alongside assemblies. `CRefPath` represents the `cref` attribute format used to cross-reference members.
+- `Signatures/` — decodes method and field binary signatures from the blob heap
+
+### TheBoxSoftware.Documentation
+
+Builds a navigable `DocumentMap` (tree of `Entry` objects) from a set of `DocumentedAssembly` instances. Key concepts:
+
+- `DocumentMapper` (abstract) — factory-created via `DocumentMapper.Create(...)`. Three strategies: `AssemblyFirstDocumentMapper`, `NamespaceFirstDocumentMapper`, `GroupedNamespaceDocumentMapper`
+- `Document` — wraps the DocumentMap and its assemblies; the central object passed through the export pipeline
+- `InputFileReader` / `LibraryFileReader` / `ProjectFileReader` / `SolutionFileReader` — read different input types (.dll, .csproj, .sln) and produce `DocumentedAssembly` lists
+- `Exporting/Exporter` (abstract) — factory-created via `Exporter.Create(document, settings, config)`. Concrete types: `WebsiteExporter`, `HtmlHelp1Exporter`, `HtmlHelp2Exporter`, `HelpViewer1Exporter`, `XmlExporter`
+- `Exporting/ExportConfigFile` — wraps a `.ldec` file (zip containing an `export.config` XML and XSLT/assets). The `.ldec` files in `ApplicationData/` define the available export formats.
+- Export pipeline: `Entry` → XML (via `Rendering/XmlRenderer`) → XSLT transform → output format
+
+### TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter (console app)
+
+Entry point: `Program.HandleExport()`. Accepts either:
+1. A single library/project/solution file with `-to`, `-format`, `-filters` flags
+2. An XML configuration file (see `example-configuration.xml`) that specifies document, filters, and multiple outputs
+
+The `AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true)` call at startup is required for XSLT processing on .NET Core (workaround for dotnet/corefx#31390).
+
+### LDEC files
+
+Export configuration packages (`.ldec`) are ZIP archives containing:
+- `export.config` — XML describing name, exporter type, XSLT path, output files, and properties
+- An XSLT stylesheet
+- Supporting assets (CSS, JS, images)
+
+Built-in formats live in `Source/TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter/ApplicationData/` and are copied to output on build.
+
+### Test projects
+
+- `TheBoxSoftware.Reflection.Tests` — NUnit 3, uses Moq; depends on `DocumentationTest` (a helper assembly of test fixtures)
+- `TheBoxSoftware.Documentation.Tests` — NUnit 3, uses Moq
+- `TheBoxSoftware.DeveloperSuite.LiveDocumenter.Exporter.Tests` — NUnit 3, uses Moq
+- `TheBoxSoftware.API.LiveDocumenter.Tests` — NUnit 3
+
+All test projects use `netcoreapp3.1`.

--- a/Source/1. Tests/99. Old/DocumentationTest/SyntaxTests/MethodTests.cs
+++ b/Source/1. Tests/99. Old/DocumentationTest/SyntaxTests/MethodTests.cs
@@ -23,6 +23,9 @@ namespace SyntaxTests
         public ForMethod ReturnClass() { return new ForMethod(); }
         public byte[] ReturnArray() { return new byte[0]; }
         public DocumentationTest.GenericClass<string,string,string> ReturnGeneric() { return new DocumentationTest.GenericClass<string, string, string>(); }
+        public (string, string) ReturnTuple() { return ("", ""); }
+        public void ParameterTuple((int, bool) arg) { }
+        public ((int, string), bool) ReturnNestedTuple() { return ((0, ""), false); }
 
         
         // static method

--- a/Source/TheBoxSoftware.Reflection.Tests/Integration/Syntax/CSharp_MethodSyntaxTests.cs
+++ b/Source/TheBoxSoftware.Reflection.Tests/Integration/Syntax/CSharp_MethodSyntaxTests.cs
@@ -48,6 +48,8 @@ namespace TheBoxSoftware.Reflection.Tests.Integration.Syntax
         [TestCase("ReturnClass", "public ForMethod ReturnClass()")]
         [TestCase("ReturnArray", "public byte[] ReturnArray()")]
         [TestCase("ReturnGeneric", "public GenericClass<string, string, string> ReturnGeneric()")]
+        [TestCase("ReturnTuple", "public (string, string) ReturnTuple()")]
+        [TestCase("ReturnNestedTuple", "public ((int, string), bool) ReturnNestedTuple()")]
         public void CSharpSyntax_Method_ReturnTypes(string method, string expected)
         {
             TestIt(method, expected);
@@ -58,6 +60,12 @@ namespace TheBoxSoftware.Reflection.Tests.Integration.Syntax
         [TestCase("ParameterOut", "public void ParameterOut(\n\tout int test\n\t)")]
         // bug 49 [TestCase("ParameterDefault", "public void ParameterDefault(\n\tint test = 3\n\t)")]
         public void CSharpSyntax_Method_ParameterModifiers(string method, string expected)
+        {
+            TestIt(method, expected);
+        }
+
+        [TestCase("ParameterTuple", "public void ParameterTuple(\n\t(int, bool) arg\n\t)")]
+        public void CSharpSyntax_Method_TupleParameter(string method, string expected)
         {
             TestIt(method, expected);
         }

--- a/Source/TheBoxSoftware.Reflection/Signatures/SignatureConvertor.cs
+++ b/Source/TheBoxSoftware.Reflection/Signatures/SignatureConvertor.cs
@@ -167,13 +167,17 @@ namespace TheBoxSoftware.Reflection.Signatures
                     break;
                 case ElementTypes.GenericInstance:
                     TypeRef genericType = ((ElementTypeSignatureToken)typeToken.Tokens[1]).ResolveToken(assembly);
-                    GetTypeName(convertedSigniture, genericType);
+                    bool isValueTuple = genericType.Namespace == "System" && genericType.Name != null && genericType.Name.StartsWith("ValueTuple");
+                    if(!isValueTuple)
+                    {
+                        GetTypeName(convertedSigniture, genericType);
+                    }
 
                     GenericArgumentCountSignatureToken argsCount = typeToken.GetGenericArgumentCount();
                     bool isFirstArgument = true;
                     if(argsCount.Count > 0)
                     {
-                        sb.Append(GenericStart);
+                        sb.Append(isValueTuple ? "(" : GenericStart);
                         for(int j = 0; j < argsCount.Count; j++)
                         {
                             if(isFirstArgument)
@@ -208,7 +212,7 @@ namespace TheBoxSoftware.Reflection.Signatures
                                 elType,
                                 argResolvedType);
                         }
-                        sb.Append(GenericEnd);
+                        sb.Append(isValueTuple ? ")" : GenericEnd);
                     }
                     break;
                 case ElementTypes.Class:

--- a/Source/TheBoxSoftware.Reflection/Syntax/CSharp/CSharpFormatter.cs
+++ b/Source/TheBoxSoftware.Reflection/Syntax/CSharp/CSharpFormatter.cs
@@ -143,10 +143,20 @@ namespace TheBoxSoftware.Reflection.Syntax.CSharp
             }
             else
             {
-                tokens.Add(FormatTypeName(details.Type));
+                bool isValueTuple = details.IsGenericInstance
+                    && details.Type != null
+                    && details.Type.Namespace == "System"
+                    && details.Type.Name != null
+                    && details.Type.Name.StartsWith("ValueTuple");
+
+                if(!isValueTuple)
+                {
+                    tokens.Add(FormatTypeName(details.Type));
+                }
+
                 if(details.IsGenericInstance)
                 {
-                    tokens.Add(Constants.GenericStart);
+                    tokens.Add(isValueTuple ? new SyntaxToken("(", SyntaxTokens.Text) : Constants.GenericStart);
                     for(int i = 0; i < details.GenericParameters.Count; i++)
                     {
                         if(i != 0)
@@ -155,7 +165,7 @@ namespace TheBoxSoftware.Reflection.Syntax.CSharp
                         }
                         tokens.AddRange(FormatTypeDetails(details.GenericParameters[i]));
                     }
-                    tokens.Add(Constants.GenericEnd);
+                    tokens.Add(isValueTuple ? new SyntaxToken(")", SyntaxTokens.Text) : Constants.GenericEnd);
                 }
             }
 


### PR DESCRIPTION
Adds support for tuple rendering in the syntax block:

```c#
public ((int, string), bool) ReturnNestedTuple()
```